### PR TITLE
Use Rails's method for detecting migration version

### DIFF
--- a/lib/generators/archer/install_generator.rb
+++ b/lib/generators/archer/install_generator.rb
@@ -11,7 +11,7 @@ module Archer
       end
 
       def migration_version
-        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+        ActiveRecord::Migration.current_version
       end
     end
   end


### PR DESCRIPTION
We can use the `Migration.current_version` provided by Rails for the
migration version.
This method was introduced in https://github.com/rails/rails/pull/21538